### PR TITLE
Open AI api Chat 기능을 위한 사전 설정

### DIFF
--- a/src/main/java/kr/ac/jnu/vocai/backend/BackendApplication.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/BackendApplication.java
@@ -1,9 +1,13 @@
 package kr.ac.jnu.vocai.backend;
 
+import kr.ac.jnu.vocai.backend.config.OpenAIProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/Message.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/Message.java
@@ -1,0 +1,10 @@
+package kr.ac.jnu.vocai.backend.chat.dto;
+
+/**
+ * Open AI Chat Completion API 전용 Request Message 객체
+ * @see <a href="https://platform.openai.com/docs/api-reference/chat/create">Chat Completion API</a>
+ * @author daecheol song
+ * @since 1.0
+ */
+public record Message(String role, String content) {
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/request/ChatRequest.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/request/ChatRequest.java
@@ -1,0 +1,15 @@
+package kr.ac.jnu.vocai.backend.chat.dto.request;
+
+import kr.ac.jnu.vocai.backend.chat.dto.Message;
+
+import java.util.List;
+
+/**
+ * Open AI Chat Completion API 전용 Request 객체.
+ * @see <a href="https://platform.openai.com/docs/api-reference/chat/create">Chat Completion API</a>
+ * @author daecheol song
+ * @since 1.0
+ */
+public record ChatRequest(String model, List<Message> messages) {
+
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/response/ChatResponse.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/chat/dto/response/ChatResponse.java
@@ -1,0 +1,13 @@
+package kr.ac.jnu.vocai.backend.chat.dto.response;
+
+import java.util.List;
+
+/**
+ * Open AI Chat Completion API 전용 Response 객체.
+ * @see <a href="https://platform.openai.com/docs/api-reference/chat/create">Chat Completion API</a>
+ * @author daecheol song
+ * @since 1.0
+ */
+public record ChatResponse(String id, List<Choice> choices, Integer created, String model) {
+    private record Choice(String finishReason, String index, String message) {}
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/config/OpenAIProperties.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/config/OpenAIProperties.java
@@ -1,0 +1,12 @@
+package kr.ac.jnu.vocai.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * OPEN AI API 프로퍼티.
+ * @author daecheol song
+ * @since 1.0
+ */
+@ConfigurationProperties("openai")
+public record OpenAIProperties(String key, String model, String chatEndpoint) {
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/config/RestTemplateConfig.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/config/RestTemplateConfig.java
@@ -1,0 +1,97 @@
+package kr.ac.jnu.vocai.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.*;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * OPEN AI API 를 사용하기 위한 RestTemplate 관련 설정.
+ * @author daecheol song
+ * @since 1.0
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class RestTemplateConfig {
+
+    private final OpenAIProperties openAIProperties;
+
+    @Bean
+    public ClientHttpRequestInterceptor customInterceptor() {
+        return (request, body, execution) -> {
+            request.getHeaders().setBearerAuth(openAIProperties.key());
+            request.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            request.getHeaders().setAccept(List.of(MediaType.APPLICATION_JSON));
+            logRequest(request, body);
+            ClientHttpResponse response = execution.execute(request, body);
+            logResponse(response);
+            return response;
+        };
+    }
+
+    @Bean
+    public RestTemplateCustomizer restTemplateCustomizer() {
+        return restTemplate -> restTemplate.getInterceptors().add(customInterceptor());
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+        return new RestTemplateBuilder(restTemplateCustomizer());
+    }
+
+    @Bean
+    public ClientHttpRequestFactory customRequestFactory() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(3000));
+        requestFactory.setReadTimeout(Duration.ofMillis(3000));
+        return new BufferingClientHttpRequestFactory(requestFactory);
+    }
+
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return restTemplateBuilder()
+                .requestFactory(this::customRequestFactory)
+                .build();
+    }
+
+
+    private void logRequest(HttpRequest request, byte[] body){
+        if (log.isDebugEnabled())
+        {
+            log.debug("===========================request begin================================================");
+            log.debug("URI         : {}", request.getURI());
+            log.debug("Method      : {}", request.getMethod());
+            log.debug("Headers     : {}", request.getHeaders());
+            log.debug("Request body: {}", new String(body, StandardCharsets.UTF_8));
+            log.debug("==========================request end================================================");
+        }
+    }
+
+    private void logResponse(ClientHttpResponse response) throws IOException {
+        if (log.isDebugEnabled())
+        {
+            log.debug("============================response begin==========================================");
+            log.debug("Status code  : {}", response.getStatusCode());
+            log.debug("Status text  : {}", response.getStatusText());
+            log.debug("Headers      : {}", response.getHeaders());
+            log.debug("Response body: {}", StreamUtils.copyToString(response.getBody(), Charset.defaultCharset()));
+            log.debug("=======================response end=================================================");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=backend
+
+openai.model=gpt-3.5-turbo-0125
+openai.key=${OPEN_API_KEY}
+openai.chat-endpoint=https://api.openai.com/v1/chat/completions
+
+logging.level.kr.ac.jnu.vocai.backend=debug

--- a/src/test/java/kr/ac/jnu/vocai/backend/BackendApplicationTests.java
+++ b/src/test/java/kr/ac/jnu/vocai/backend/BackendApplicationTests.java
@@ -1,13 +1,26 @@
 package kr.ac.jnu.vocai.backend;
 
+import kr.ac.jnu.vocai.backend.config.OpenAIProperties;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ConfigurationPropertiesScan
 class BackendApplicationTests {
+
+	private final OpenAIProperties properties;
+
+	public BackendApplicationTests(@Autowired OpenAIProperties properties) {
+		this.properties = properties;
+	}
 
 	@Test
 	void contextLoads() {
+		Assertions.assertThat(properties.key()).isNotNull().isNotEqualTo("${OPEN_API_KEY}");
+		Assertions.assertThat(properties.model()).isNotNull();
 	}
 
 }

--- a/src/test/java/kr/ac/jnu/vocai/backend/config/RestTemplateConfigTest.java
+++ b/src/test/java/kr/ac/jnu/vocai/backend/config/RestTemplateConfigTest.java
@@ -1,0 +1,35 @@
+package kr.ac.jnu.vocai.backend.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+/**
+ * @author daecheol song
+ * @since 1.0
+ */
+@ConfigurationPropertiesScan
+@SpringJUnitConfig(classes = {RestTemplateConfig.class})
+public class RestTemplateConfigTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void given_whenSearchingRestTemplateBuilderBean_thenReturnsNotNull() {
+        //given
+        //when
+        RestTemplateBuilder restTemplateBuilder = context.getBean(RestTemplateBuilder.class);
+        //then
+        assertThat(restTemplateBuilder).isNotNull();
+    }
+}


### PR DESCRIPTION
- Open AI api 관련 프로퍼티 설정 (chat-url, key, model), key는 외부 주입
- Chat api 전용 request, response 객체 추가
- RestTemplate 설정 및 테스트