### PR TITLE
#11 - pdf,image file upload 구현

### DIFF
--- a/src/main/java/kr/ac/jnu/vocai/backend/controller/UploadController.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/controller/UploadController.java
@@ -1,0 +1,53 @@
+package kr.ac.jnu.vocai.backend.controller;
+
+import kr.ac.jnu.vocai.backend.file.FileUploadUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * 파일 업로드 컨트롤러 클래스.
+ * @author wavewwave20
+ * @since 1.0
+ */
+@Slf4j
+@Controller
+public class UploadController {
+
+    private String uploadDir = "c:/dev/postman/uploaded";
+
+    private FileUploadUtils fileUploadUtils;
+
+    @Autowired
+    public UploadController(FileUploadUtils fileUploadUtils) {
+        this.fileUploadUtils = fileUploadUtils;
+    }
+
+    @PostMapping("/pdf/upload")
+    public ResponseEntity<String> saveFiles(@RequestParam("files") MultipartFile[] files) throws IOException {
+
+        if (files.length > 3) {
+            return ResponseEntity.badRequest().body("cannot upload more than 3 files");
+        }
+        if (files.length == 0) {
+            return ResponseEntity.badRequest().body("no files to upload");
+        }
+        for (MultipartFile file : files) {
+            log.info("file name: {}", file.getOriginalFilename());
+            log.info("file size: {}", file.getSize());
+            log.info("file content type: {}", file.getContentType());
+
+            // 파일 저장
+            file.transferTo(new File(uploadDir + "/" + FileUploadUtils.fileNameConvert(file.getOriginalFilename())));
+        }
+        return ResponseEntity.ok("upload success");
+    }
+
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/file/FileUploadUtils.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/file/FileUploadUtils.java
@@ -1,0 +1,51 @@
+package kr.ac.jnu.vocai.backend.file;
+
+import org.springframework.stereotype.Component;
+import kr.ac.jnu.vocai.backend.file.exception.InvalidFileExtensionException;
+
+import java.util.UUID;
+
+/**
+ * 업로드 파일을 uuid로 저장하는 클래스.
+ * @author wavewwave20
+ * @since 1.0
+ */
+
+@Component
+public class FileUploadUtils {
+
+    public static boolean isImage(String fileName) {
+        String extension = getExtension(fileName);
+
+        return extension.equals("jpg") || extension.equals("jpeg") || extension.equals("png") || extension.equals("gif");
+    }
+
+    public static boolean isPdf(String fileName) {
+        String extension = getExtension(fileName);
+
+        return extension.equals("pdf");
+    }
+
+    public static String fileNameConvert(String fileName) {
+        if (!(isImage(fileName) || isPdf(fileName))) {
+            String extension = getExtension(fileName);
+            throw new InvalidFileExtensionException("Invalid file extension: " + extension);
+        }
+
+        StringBuilder builder = new StringBuilder();
+        UUID uuid = UUID.randomUUID();
+        String extension = getExtension(fileName);
+
+        builder.append(uuid).append(".").append(extension);
+
+        return builder.toString();
+    }
+
+    // 확장자 추출
+    private static String getExtension(String fileName) {
+        int pos = fileName.lastIndexOf(".");
+
+        return fileName.substring(pos + 1);
+    }
+
+}

--- a/src/main/java/kr/ac/jnu/vocai/backend/file/exception/InvalidFileExtensionException.java
+++ b/src/main/java/kr/ac/jnu/vocai/backend/file/exception/InvalidFileExtensionException.java
@@ -1,0 +1,12 @@
+package kr.ac.jnu.vocai.backend.file.exception;
+
+/**
+ * 파일 확장자가 유효하지 않을 때 발생하는 exception 클래스.
+ * @author wavewwave20
+ * @since 1.0
+ */
+public class InvalidFileExtensionException extends RuntimeException{
+    public InvalidFileExtensionException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
엔드포인트 | /pdf/upload
-- | --
메서드 | POST
요청 형식 | Multipart/form-data
요청 파라미터 | files
최대 파일 개수 | 3
허용 파일 형식 | PDF, JPG, JPEG, PNG, GIF

최대 파일 개수 3개로 제한.
허용 파일 형식 pdf/이미지
중복 파일 있을 수 있으므로 파일 저장시 파일명 uuid로 변경